### PR TITLE
Add support for <template> tags

### DIFF
--- a/__tests__/data.js
+++ b/__tests__/data.js
@@ -18,3 +18,37 @@ export const TEST_1_TAG = ["html", "head", "title", "body", "div", "a", "input"]
 export const TEST_1_CLASS = ["test-container", "test-footer", "a-link"]
 
 export const TEST_1_ID = ["a-link", "blo"]
+
+export const TEST_2_CONTENT = `
+<template>
+    <div id="app">
+        <div class="test-container">Well</div>
+        <div class="test-footer" id="an-id"></div>
+        <a href="#" id="a-link" class="a-link"></a>
+        <input id="blo" type="text" disabled/>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'its-just-a-test'
+}
+</script>
+
+<style>
+    .test-container {
+        color: darkgray;
+        text-align: center;
+    }
+
+    .test-footer {
+        font-weight: bold;
+    }
+</style>
+`
+
+export const TEST_2_TAG = ["div", "a", "input"]
+
+export const TEST_2_CLASS = ["test-container", "test-footer", "a-link"]
+
+export const TEST_2_ID = ["a-link", "blo"]

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,5 +1,6 @@
 import purgehtml from "./../index.js"
 import { TEST_1_CONTENT, TEST_1_TAG, TEST_1_CLASS, TEST_1_ID } from "./data"
+import { TEST_2_CONTENT, TEST_2_TAG, TEST_2_CLASS, TEST_2_ID } from "./data"
 
 describe("purgehtml", () => {
     it("finds tag selectors", () => {
@@ -29,5 +30,36 @@ describe("purgehtml", () => {
         for (let item of selectors) {
             expect(received.includes(item)).toBe(true)
         }
+    })
+
+    describe("from a template tag", () => {
+        it("finds tag selectors", () => {
+            const received = purgehtml.extract(TEST_2_CONTENT)
+            for (let item of TEST_2_TAG) {
+                expect(received.includes(item)).toBe(true)
+            }
+        })
+
+        it("finds classes selectors", () => {
+            const received = purgehtml.extract(TEST_2_CONTENT)
+            for (let item of TEST_2_CLASS) {
+                expect(received.includes(item)).toBe(true)
+            }
+        })
+
+        it("finds id selectors", () => {
+            const received = purgehtml.extract(TEST_2_CONTENT)
+            for (let item of TEST_2_ID) {
+                expect(received.includes(item)).toBe(true)
+            }
+        })
+
+        it("finds all selectors", () => {
+            const received = purgehtml.extract(TEST_2_CONTENT)
+            const selectors = [...TEST_2_TAG, ...TEST_2_CLASS, ...TEST_2_ID]
+            for (let item of selectors) {
+                expect(received.includes(item)).toBe(true)
+            }
+        })
     })
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -3,34 +3,36 @@ import { TEST_1_CONTENT, TEST_1_TAG, TEST_1_CLASS, TEST_1_ID } from "./data"
 import { TEST_2_CONTENT, TEST_2_TAG, TEST_2_CLASS, TEST_2_ID } from "./data"
 
 describe("purgehtml", () => {
-    it("finds tag selectors", () => {
-        const received = purgehtml.extract(TEST_1_CONTENT)
-        for (let item of TEST_1_TAG) {
-            expect(received.includes(item)).toBe(true)
-        }
-    })
+    describe("from a normal html document", () => {
+        it("finds tag selectors", () => {
+            const received = purgehtml.extract(TEST_1_CONTENT)
+            for (let item of TEST_1_TAG) {
+                expect(received.includes(item)).toBe(true)
+            }
+        })
 
-    it("finds classes selectors", () => {
-        const received = purgehtml.extract(TEST_1_CONTENT)
-        for (let item of TEST_1_CLASS) {
-            expect(received.includes(item)).toBe(true)
-        }
-    })
+        it("finds classes selectors", () => {
+            const received = purgehtml.extract(TEST_1_CONTENT)
+            for (let item of TEST_1_CLASS) {
+                expect(received.includes(item)).toBe(true)
+            }
+        })
 
-    it("finds id selectors", () => {
-        const received = purgehtml.extract(TEST_1_CONTENT)
-        for (let item of TEST_1_ID) {
-            expect(received.includes(item)).toBe(true)
-        }
-    })
+        it("finds id selectors", () => {
+            const received = purgehtml.extract(TEST_1_CONTENT)
+            for (let item of TEST_1_ID) {
+                expect(received.includes(item)).toBe(true)
+            }
+        })
 
-    it("finds all selectors", () => {
-        const received = purgehtml.extract(TEST_1_CONTENT)
-        const selectors = [...TEST_1_TAG, ...TEST_1_CLASS, ...TEST_1_ID]
-        for (let item of selectors) {
-            expect(received.includes(item)).toBe(true)
-        }
-    })
+        it("finds all selectors", () => {
+            const received = purgehtml.extract(TEST_1_CONTENT)
+            const selectors = [...TEST_1_TAG, ...TEST_1_CLASS, ...TEST_1_ID]
+            for (let item of selectors) {
+                expect(received.includes(item)).toBe(true)
+            }
+        })
+    });
 
     describe("from a template tag", () => {
         it("finds tag selectors", () => {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const getSelectorsInNodes = node => {
         } else if (childNode.type === "root") {
             selectors = [
                 ...selectors,
-                getSelectorsInNodes(childNode)
+                ...getSelectorsInNodes(childNode)
             ]
         }
     }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ const getSelectorsInNodes = node => {
                 ...ids,
                 ...getSelectorsInNodes(childNode)
             ]
+        } else if (childNode.type === "root") {
+            return getSelectorsInNodes(childNode);
         }
     }
     return selectors

--- a/index.js
+++ b/index.js
@@ -21,7 +21,10 @@ const getSelectorsInNodes = node => {
                 ...getSelectorsInNodes(childNode)
             ]
         } else if (childNode.type === "root") {
-            return getSelectorsInNodes(childNode);
+            selectors = [
+                ...selectors,
+                getSelectorsInNodes(childNode)
+            ]
         }
     }
     return selectors

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    testEnvironment: "node"
+}


### PR DESCRIPTION
[`parse5`] seems to handle `<template>` tags differently from other tags by wrapping child nodes in a `root` type node, which causes `purgecss-from-html` to skip children of template elements altogether. Adding support for `<template>` nodes supports Single File Components, as used by [Vue.js] and other frameworks.

Here's what I did to support them:

- [x] Set Jest's `testEnvironment` configuration to `node` to avoid [errors with JSDOM]
- [x] Organize the existing tests into a sub-group/suite for normal HTML documents
- [x] Add fixtures and tests for a simple Single File Component similar to the existing test HTML document
- [x] Implement the fix by gathering selectors from `root` type nodes and adding to the `selectors` return array

Please let me know if you want the `testEnvironment` extracted into a separate PR, or if I should update Jest to a newer version since [that error has been fixed].

[`parse5`]: https://github.com/inikulin/parse5
[Vue.js]: https://vuejs.org/v2/guide/single-file-components.html
[errors with JSDom]: https://github.com/facebook/jest/issues/6766
[that error has been fixed]: https://github.com/facebook/jest/pull/6792